### PR TITLE
Openflow 1.3#4

### DIFF
--- a/src/main/java/net/floodlightcontroller/core/IOFSwitch.java
+++ b/src/main/java/net/floodlightcontroller/core/IOFSwitch.java
@@ -37,12 +37,14 @@ import org.projectfloodlight.openflow.types.OFPort;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
-
+import net.floodlightcontroller.core.web.serializers.IOFSwitchSerializer;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 /**
  * An openflow switch connecting to the controller.  This interface offers
  * methods for interacting with switches using OpenFlow, and retrieving
  * information about the switches.
  */
+@JsonSerialize(using=IOFSwitchSerializer.class)
 public interface IOFSwitch extends IOFMessageWriter {
     // Attribute keys
     // These match our YANG schema, make sure they are in sync

--- a/src/main/java/net/floodlightcontroller/core/web/serializers/IOFSwitchSerializer.java
+++ b/src/main/java/net/floodlightcontroller/core/web/serializers/IOFSwitchSerializer.java
@@ -1,0 +1,198 @@
+/**
+*    Copyright 2011,2012 Big Switch Networks, Inc. 
+*    Originally created by David Erickson, Stanford University
+* 
+*    Licensed under the Apache License, Version 2.0 (the "License"); you may
+*    not use this file except in compliance with the License. You may obtain
+*    a copy of the License at
+*
+*         http://www.apache.org/licenses/LICENSE-2.0
+*
+*    Unless required by applicable law or agreed to in writing, software
+*    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+*    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+*    License for the specific language governing permissions and limitations
+*    under the License.
+**/
+
+package net.floodlightcontroller.core.web.serializers;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.Map;
+import java.util.Collection;
+import java.util.EnumSet;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import org.projectfloodlight.openflow.util.HexString;
+import org.projectfloodlight.openflow.types.DatapathId;
+import org.projectfloodlight.openflow.protocol.OFCapabilities;
+import org.projectfloodlight.openflow.protocol.OFPortDesc;
+import org.projectfloodlight.openflow.protocol.OFPortConfig;
+import org.projectfloodlight.openflow.protocol.OFPortFeatures;
+import org.projectfloodlight.openflow.protocol.OFPortState;
+import org.projectfloodlight.openflow.protocol.OFActionType;
+import org.projectfloodlight.openflow.protocol.OFControllerRole;
+import org.projectfloodlight.openflow.protocol.OFFlowWildcards;
+import org.projectfloodlight.openflow.protocol.OFVersion;
+import net.floodlightcontroller.core.HARole;
+import net.floodlightcontroller.core.IOFSwitch;
+import net.floodlightcontroller.core.SwitchDescription;
+/**
+ * Serialize a IOFSwitch for more readable information
+ */
+public class IOFSwitchSerializer extends JsonSerializer<IOFSwitch> {
+
+    @Override
+    public void serialize(IOFSwitch sw, JsonGenerator jGen,
+                          SerializerProvider serializer)
+                                  throws IOException, JsonProcessingException {
+        jGen.writeStartObject();
+        jGen.writeStringField("dpid",sw.getId().toString());
+        serializeCapabilities(sw.getCapabilities(),jGen);
+        serializeDescription(sw.getSwitchDescription(),jGen);
+        serializeHarole(sw.getControllerRole(),jGen);
+        serializeActions(sw.getActions(),jGen);
+        serializeAttributes(sw.getAttributes(),jGen);
+        serializePorts(sw.getPorts(),jGen);
+        jGen.writeNumberField("buffers",sw.getBuffers());
+        jGen.writeStringField("inetAddress",sw.getInetAddress().toString());
+        jGen.writeNumberField("tables",sw.getTables());
+        jGen.writeNumberField("connectedSince",sw.getConnectedSince().getTime());
+        jGen.writeEndObject();
+    }
+
+    public void serializeActions(Set<OFActionType> actions, JsonGenerator jGen)
+            throws IOException, JsonProcessingException {
+        if ( null == actions)
+            jGen.writeStringField("actions","null");
+        else{
+            jGen.writeFieldName("actions");
+            jGen.writeStartArray();
+            for(OFActionType action : actions){
+                jGen.writeString(action.toString());
+            }
+            jGen.writeEndArray();
+        }
+    }
+
+    public void serializeAttributes(Map<Object, Object> attributes, JsonGenerator jGen)
+            throws IOException, JsonProcessingException {
+        if ( null == attributes)
+            jGen.writeStringField("attributes","null");
+        else{
+            jGen.writeFieldName("attributes");
+            jGen.writeStartObject();
+            for (Map.Entry<Object, Object> entry : attributes.entrySet()) {
+                if( entry.getValue() instanceof EnumSet<?>){
+                    jGen.writeFieldName(entry.getKey().toString());
+                    jGen.writeStartArray();
+                    //Maybe need to check other type.
+                    for(OFFlowWildcards  wildcard : (EnumSet<OFFlowWildcards>)entry.getValue()){
+                        jGen.writeString(wildcard.toString());
+                    }
+                    jGen.writeEndArray();
+                }
+                else
+                    jGen.writeStringField(entry.getKey().toString(),entry.getValue().toString());
+            }
+            jGen.writeEndObject();
+        }
+    }
+    public void serializePorts(Collection<OFPortDesc> portDecs, JsonGenerator jGen)
+            throws IOException, JsonProcessingException {
+            if ( portDecs == null)
+                jGen.writeStringField("ports","null");
+            else{
+                jGen.writeFieldName("ports");
+                jGen.writeStartArray();
+                for(OFPortDesc port : portDecs){
+                    jGen.writeStartObject();
+                    jGen.writeNumberField("PortNo",port.getPortNo().getPortNumber());
+                    jGen.writeStringField("HwAddr",port.getHwAddr().toString());
+                    jGen.writeStringField("Name",port.getName());
+                    if ( port.getVersion() != OFVersion.OF_10){
+                        jGen.writeNumberField("CurrSpeed",port.getCurrSpeed());
+                        jGen.writeNumberField("MaxSpeed",port.getMaxSpeed());
+                    }
+                    jGen.writeFieldName("config");
+                    jGen.writeStartArray();
+                    for(OFPortConfig config : port.getConfig()){
+                        jGen.writeString(config.toString());
+                    }
+                    jGen.writeEndArray();
+                    jGen.writeFieldName("state");
+                    jGen.writeStartArray();
+                    for(OFPortState state : port.getState()){
+                        jGen.writeString(state.toString());
+                    }
+                    jGen.writeEndArray();
+
+                    jGen.writeFieldName("curr");
+                    jGen.writeStartArray();
+                    for(OFPortFeatures curr : port.getCurr()){
+                        jGen.writeString(curr.toString());
+                    }
+                    jGen.writeEndArray();
+                    jGen.writeFieldName("advertised");
+                    jGen.writeStartArray();
+                    for(OFPortFeatures advertised : port.getAdvertised()){
+                        jGen.writeString(advertised.toString());
+                    }
+                    jGen.writeEndArray();
+                    jGen.writeFieldName("supported");
+                    jGen.writeStartArray();
+                    for(OFPortFeatures support : port.getSupported()){
+                        jGen.writeString(support.toString());
+                    }
+                    jGen.writeEndArray();
+                    jGen.writeFieldName("peer");
+                    jGen.writeStartArray();
+                    for(OFPortFeatures peer : port.getPeer()){
+                        jGen.writeString(peer.toString());
+                    }
+                    jGen.writeEndArray();
+                    jGen.writeEndObject();
+                }
+                jGen.writeEndArray();
+        
+            }
+    }
+    public void serializeDescription(SwitchDescription swDescription, JsonGenerator jGen)
+            throws IOException, JsonProcessingException {
+        if( null == swDescription)
+            jGen.writeStringField("description","null");
+        else{
+            jGen.writeFieldName("description");
+            jGen.writeStartObject();
+            jGen.writeStringField("datapath",swDescription.getDatapathDescription());
+            jGen.writeStringField("hardware",swDescription.getHardwareDescription());
+            jGen.writeStringField("manufacturer",swDescription.getManufacturerDescription());
+            jGen.writeStringField("serialNum",swDescription.getSerialNumber());
+            jGen.writeStringField("software",swDescription.getSoftwareDescription());
+            jGen.writeEndObject();
+        }
+    }
+    public void serializeCapabilities(Set<OFCapabilities> ofCapabilities, JsonGenerator jGen)
+            throws IOException, JsonProcessingException {
+        if (null == ofCapabilities)
+            jGen.writeStringField("capabilities","null");
+        else{
+            jGen.writeFieldName("capabilities");
+            jGen.writeStartArray();
+            for(OFCapabilities ofCapability : ofCapabilities){
+                jGen.writeString(ofCapability.toString());
+            }
+            jGen.writeEndArray();
+        }
+    }
+    public void serializeHarole(OFControllerRole role, JsonGenerator jGen)
+            throws IOException, JsonProcessingException {
+        if ( null == role )
+            jGen.writeStringField("harole","null");
+        else
+            jGen.writeStringField("harole",HARole.ofOFRole(role).toString());
+    }
+}


### PR DESCRIPTION
Hi.

As i had mentioned in the issue#3, there will a error message when we use the "/wm/core/controller/switches/json" REST API to fetch the switches information on the OF1.0. I think that is caused by the serializer which calls a unsupported function. I think the solution is that we create a custom serializer for the result value.
## Solution
1. Create a custom serializer IOFSwitchSerializer for IOFSwitch.
2. Ask the IOFSwitch use tat custom serializer to serialize when it needs.
3. Since the ControllerSwitchesResource is responsible for processing the REST request for "/wm/core/controller/switches/json", I modify its return value to a set of IOFSwitch instead of the original iterator.
## Result
1. It work for OF1.0 and OF1.3
2. I have test the following format and all work.
   -  /wm/core/controller/switches/json
   -  /wm/core/controller/switches/json?dpid=00:00:00:00:00:00:00:01
   -  /wm/core/controller/switches/json?Dpid__StartsWith=00:00

Feel free to give your comments about this problem.

Thanks.
