### PR TITLE
Modified Forwarding and ForwardingBase to use setInstructions instead…

### DIFF
--- a/src/main/java/net/floodlightcontroller/forwarding/Forwarding.java
+++ b/src/main/java/net/floodlightcontroller/forwarding/Forwarding.java
@@ -51,6 +51,7 @@ import net.floodlightcontroller.routing.IRoutingService;
 import net.floodlightcontroller.routing.Route;
 import net.floodlightcontroller.topology.ITopologyService;
 import net.floodlightcontroller.topology.NodePortTuple;
+import net.floodlightcontroller.util.FlowModUtils;
 import net.floodlightcontroller.util.OFDPAUtils;
 import net.floodlightcontroller.util.OFPortMode;
 import net.floodlightcontroller.util.OFPortModeTuple;
@@ -139,8 +140,9 @@ public class Forwarding extends ForwardingBase implements IFloodlightModule, IOF
 		.setIdleTimeout(FLOWMOD_DEFAULT_IDLE_TIMEOUT)
 		.setBufferId(OFBufferId.NO_BUFFER)
 		.setMatch(m)
-		.setActions(actions) // empty list
 		.setPriority(FLOWMOD_DEFAULT_PRIORITY);
+		
+		FlowModUtils.setActions(fmb, actions, sw);
 
 		try {
 			if (log.isDebugEnabled()) {

--- a/src/main/java/net/floodlightcontroller/routing/ForwardingBase.java
+++ b/src/main/java/net/floodlightcontroller/routing/ForwardingBase.java
@@ -41,6 +41,7 @@ import net.floodlightcontroller.routing.IRoutingDecision;
 import net.floodlightcontroller.routing.Route;
 import net.floodlightcontroller.topology.ITopologyService;
 import net.floodlightcontroller.topology.NodePortTuple;
+import net.floodlightcontroller.util.FlowModUtils;
 import net.floodlightcontroller.util.MatchUtils;
 import net.floodlightcontroller.util.OFDPAUtils;
 import net.floodlightcontroller.util.OFMessageDamper;
@@ -247,13 +248,14 @@ public abstract class ForwardingBase implements IOFMessageListener {
 			}
 			
 			fmb.setMatch(mb.build())
-			.setActions(actions)
 			.setIdleTimeout(FLOWMOD_DEFAULT_IDLE_TIMEOUT)
 			.setHardTimeout(FLOWMOD_DEFAULT_HARD_TIMEOUT)
 			.setBufferId(OFBufferId.NO_BUFFER)
 			.setCookie(cookie)
 			.setOutPort(outPort)
 			.setPriority(FLOWMOD_DEFAULT_PRIORITY);
+			
+			FlowModUtils.setActions(fmb, actions, sw);
 			
 			try {
 				if (log.isTraceEnabled()) {
@@ -445,8 +447,9 @@ public abstract class ForwardingBase implements IOFMessageListener {
 		.setIdleTimeout(FLOWMOD_DEFAULT_IDLE_TIMEOUT)
 		.setPriority(FLOWMOD_DEFAULT_PRIORITY)
 		.setBufferId(OFBufferId.NO_BUFFER)
-		.setMatch(mb.build())
-		.setActions(actions);
+		.setMatch(mb.build());
+		
+		FlowModUtils.setActions(fmb, actions, sw);
 
 		log.debug("write drop flow-mod sw={} match={} flow-mod={}",
 					new Object[] { sw, mb.build(), fmb.build() });

--- a/src/main/java/net/floodlightcontroller/util/FlowModUtils.java
+++ b/src/main/java/net/floodlightcontroller/util/FlowModUtils.java
@@ -1,5 +1,10 @@
 package net.floodlightcontroller.util;
 
+import java.util.Collections;
+import java.util.List;
+
+import net.floodlightcontroller.core.IOFSwitch;
+
 import org.projectfloodlight.openflow.protocol.OFFactories;
 import org.projectfloodlight.openflow.protocol.OFFlowAdd;
 import org.projectfloodlight.openflow.protocol.OFFlowDelete;
@@ -8,6 +13,8 @@ import org.projectfloodlight.openflow.protocol.OFFlowMod;
 import org.projectfloodlight.openflow.protocol.OFFlowModify;
 import org.projectfloodlight.openflow.protocol.OFFlowModifyStrict;
 import org.projectfloodlight.openflow.protocol.OFVersion;
+import org.projectfloodlight.openflow.protocol.action.OFAction;
+import org.projectfloodlight.openflow.protocol.instruction.OFInstruction;
 
 /**
  * Convert an OFFlowMod to a specific OFFlowMod-OFFlowModCommand.
@@ -219,6 +226,25 @@ public class FlowModUtils {
 					.setTableId(fm.getTableId())
 					.setXid(fm.getXid())
 					.build();
+		}
+	}
+	
+	/**
+	 * Sets the actions in fmb according to the sw version.
+	 * 
+	 * @param fmb the FlowMod Builder that is being built
+	 * @param actions the actions to set
+	 * @param sw the switch that will receive the FlowMod
+	 */
+	public static void setActions(OFFlowMod.Builder fmb,
+			List<OFAction> actions, IOFSwitch sw) {
+		if (sw.getOFFactory().getVersion().compareTo(OFVersion.OF_11) >= 0) {
+			// Instructions are used starting in OF 1.1
+			fmb.setInstructions(Collections.singletonList((OFInstruction) sw
+					.getOFFactory().instructions().applyActions(actions)));
+		} else {
+			// OF 1.0 only supports actions
+			fmb.setActions(actions);
 		}
 	}
 }


### PR DESCRIPTION
… of setActions in OF 1.1 or later. New openflowj-2.0.0-SNAPSHOT.jar that duplicates the shortcut used for FlowMod setActions in version 1.3 to versions 1.1, 1.2 and 1.4